### PR TITLE
Update to secure user credentials

### DIFF
--- a/twitter/twitter.html
+++ b/twitter/twitter.html
@@ -2,36 +2,69 @@
 
 <script type="text/x-red" data-template-name="twitter-api-connection">
     <div class="form-row">
+        <label for="node-config-input-connectionName" style="width:30%"><i class="icon-bookmark"></i> Connection Name</label>
+        <input type="text" id="node-config-input-connectionName" style="width:65%">
+    </div>
+    <div class="form-row">
         <label for="node-config-input-consumerKey" style="width:30%"><i class="icon-bookmark"></i> Consumer Key</label>
-        <input type="text" id="node-config-input-consumerKey" style="width:65%">
+        <input type="password" id="node-config-input-consumerKey" style="width:65%">
     </div>
     <div class="form-row">
         <label for="node-config-input-consumerSecret" style="width:30%"><i class="icon-bookmark"></i> Consumer Secret</label>
-        <input type="text" id="node-config-input-consumerSecret" style="width:65%">
+        <input type="password" id="node-config-input-consumerSecret" style="width:65%">
     </div>
     <div class="form-row">
         <label for="node-config-input-accessToken" style="width:30%"><i class="icon-bookmark"></i> Access Token</label>
-        <input type="text" id="node-config-input-accessToken" style="width:65%">
+        <input type="password" id="node-config-input-accessToken" style="width:65%">
     </div>
     <div class="form-row">
         <label for="node-config-input-accessSecret" style="width:30%"><i class="icon-bookmark"></i> Access Secret</label>
-        <input type="text" id="node-config-input-accessSecret" style="width:65%">
+        <input type="password" id="node-config-input-accessSecret" style="width:65%">
     </div>
 </script>
 
 <script type="text/javascript">
+(function() {
+    var twitterConfigNodeId = null;
+    var twitterConfigNodeIntervalId = null;
+
     RED.nodes.registerType('twitter-api-connection',{
         category: 'config',
         defaults: {
-            consumerKey: {value:"", required:true},
-            consumerSecret: {value:"", required:true},
-            accessToken: {value:"", required:true},
-            accessSecret: {value:"", required:true},
+            connectionName: {value:""}
+        },
+        credentials: {
+            consumerKey: { type: "password"},
+            consumerSecret: { type: "password" },
+            accessToken: {type: "password"},
+            accessSecret: {type:"password"}
         },
         label: function() {
-            return this.consumerKey;
+            if (this.connectionName) {
+                return (this.connectionName)
+            } else {
+                return "Twitter: "+this.id
+            }
+        },
+        //Ensure API credentials are not exportable
+        exportable: false,
+        oneditsave: function() {
+            var trimFields = [
+                "consumerKey",
+                "consumerSecret",
+                "accessToken",
+                "accessSecret"
+            ];
+            // Remove whitespace from the copy-paste of the fields
+            trimFields.forEach(function(field) {
+                var v = $("#node-config-input-"+field).val();
+                v = v.trim();
+                $("#node-config-input-"+field).val(v);
+
+            });
         }
     });
+})();
 </script>
 
 <!-- Twitter streaming API --> 

--- a/twitter/twitter.js
+++ b/twitter/twitter.js
@@ -14,20 +14,15 @@ module.exports = function(RED) {
     function TwitterAPIConnection(n) {
         RED.nodes.createNode(this,n);
         var node = this;
-        node.consumerKey = n.consumerKey;
-        node.consumerSecret = n.consumerSecret;
-        node.accessToken = n.accessToken;
-        node.accessSecret = n.accessSecret;
-
-        var id = node.consumerKey;
-
+        
+        var id = n.connectionName;
         node.log('create new Twitter instance for: ' + id);
         
         clients[id] = new Twit({
-            consumer_key: node.consumerKey,
-            consumer_secret: node.consumerSecret,
-            access_token: node.accessToken,
-            access_token_secret: node.accessSecret
+            consumer_key: node.credentials.consumerKey,
+            consumer_secret: node.credentials.consumerSecret,
+            access_token: node.credentials.accessToken,
+            access_token_secret: node.credentials.accessSecret
         });
         
         node.client = clients[id];
@@ -37,7 +32,15 @@ module.exports = function(RED) {
             delete clients[id];
         });
     }
-    RED.nodes.registerType("twitter-api-connection",TwitterAPIConnection);
+
+    RED.nodes.registerType("twitter-api-connection",TwitterAPIConnection,{
+        credentials: {
+            consumerKey: {type: "password"},
+            consumerSecret: {type: "password"},
+            accessToken: {type: "password"},
+            accessSecret: {type:"password"}
+        }
+    });
 
     //Twitter stream
     function TwitterStream(n) {


### PR DESCRIPTION
Instruction for handling node credentials are available here: https://nodered.org/docs/creating-nodes/credentials

As advised, the official Twitter Node was (https://github.com/node-red/node-red-nodes) used as an example and modified accordingly.

The update adds a new field 'Connection Name' has been added to the API Connection Node enabling the user to give the credentials a meaningful label (e.g. 'Connection1'). Otherwise Node-Red assigns its own (something like 'Twitter: eghraghmfn') . 

![image](https://user-images.githubusercontent.com/10799911/78715101-d189d780-7914-11ea-8a4d-91f248556248.png)

This label is also used to identify the particular connection in the Node-Red terminal logs.

![image](https://user-images.githubusercontent.com/10799911/78715396-465d1180-7915-11ea-8dd3-3bd2257328e0.png)

Credentials are now encrypted within the `flow_cred.json` file. When the user exports the `flow.json` or uploads to github the only visible details are the user generated connection name. The other details are not revealed.

![image](https://user-images.githubusercontent.com/10799911/78715745-c08d9600-7915-11ea-88b2-3b163fbcf14f.png)
